### PR TITLE
Pointer files

### DIFF
--- a/packages/audiofileindex/src/AudioFileIndex.ts
+++ b/packages/audiofileindex/src/AudioFileIndex.ts
@@ -73,7 +73,8 @@ export type AudioFileIndex = {
 const AFITypeTag = Symbol.for('freik.AudioFileIndexTag');
 
 // Helpers for the file list stuff
-const audioTypes = MakeSuffixWatcher('flac', 'mp3', 'aac', 'm4a');
+// emp => A JSON file pointing to another file, with (maybe) metadata overrides
+const audioTypes = MakeSuffixWatcher('flac', 'mp3', 'aac', 'm4a', 'emp');
 // Any other image types to care about?
 const imageTypes = MakeSuffixWatcher('png', 'jpg', 'jpeg', 'heic', 'hei');
 function watchTypes(pathName: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20798,13 +20798,13 @@ __metadata:
   linkType: hard
 
 "semver@npm:^7.5.3":
-  version: 7.5.4
-  resolution: "semver@npm:7.5.4"
+  version: 7.5.3
+  resolution: "semver@npm:7.5.3"
   dependencies:
     lru-cache: ^6.0.0
   bin:
     semver: bin/semver.js
-  checksum: 12d8ad952fa353b0995bf180cdac205a4068b759a140e5d3c608317098b3575ac2f1e09182206bf2eb26120e1c0ed8fb92c48c592f6099680de56bb071423ca3
+  checksum: 9d58db16525e9f749ad0a696a1f27deabaa51f66e91d2fa2b0db3de3e9644e8677de3b7d7a03f4c15bc81521e0c3916d7369e0572dbde250d9bedf5194e2a8a7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
You can create a little JSON file that contains '{"original":"../relative-path/to-the.mp3"}' and name it "03 - a song.emp" and it will work as if it's the original song, but with the path/album/artist/title of the .emp song location. Good for file savings (that isn't really important, but I have too many dupes in my gigantic music collection, and this might encourage me to clean it up)